### PR TITLE
fix: ecorevx's Eco_Page_New function prototype mismatch

### DIFF
--- a/src/base/ecorevx/core/memory/heap.c
+++ b/src/base/ecorevx/core/memory/heap.c
@@ -8,7 +8,7 @@ static struct Eco_Page* Eco_Heap_AllocateNewPageToEden(struct Eco_Heap* self)
         page = self->free_page_list;
         Eco_Page_ListUnlink(page);
     } else {
-        page = Eco_Page_New();
+        page = Eco_Page_New(self);
         if (page == NULL)
             return NULL;
     }

--- a/src/base/ecorevx/core/memory/page.h
+++ b/src/base/ecorevx/core/memory/page.h
@@ -167,8 +167,8 @@ static inline bool Eco_Page_HasSpaceFor(struct Eco_Page* self, Eco_Size_t size)
     return Eco_Page_GetFreeSpace(self) >= size;
 }
 
-
-struct Eco_Page* Eco_Page_New();
+struct Eco_Heap;
+struct Eco_Page* Eco_Page_New(struct Eco_Heap* heap);
 void             Eco_Page_Delete(struct Eco_Page*);
 
 void*            Eco_Page_Alloc(struct Eco_Page*, Eco_Size_t);


### PR DESCRIPTION
I guess this is how it is supposed to work. I can only compile after making this change.